### PR TITLE
Use '--use-pihole' flag from pivpn

### DIFF
--- a/pivpn-pihole-cloudformation.yml
+++ b/pivpn-pihole-cloudformation.yml
@@ -172,13 +172,7 @@ Resources:
           EOT
 
           mkdir -p /usr/local/src/pivpn
-          curl -L https://install.pivpn.io | bash /dev/stdin --unattended pivpn.conf
-
-          pivpnNET=$(cat /etc/pivpn/wireguard/setupVars.conf | grep pivpnNET | sed -E 's/(pivpnNET=)(.+)/\2/g')
-          pivpnDNS1=$(echo $pivpnNET | sed -E 's/([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)([0-9]{1,3})/\11/g')
-          sed -i -E "s/(pivpnDNS1=).+/\1$pivpnDNS1/g" /etc/pivpn/wireguard/setupVars.conf
-          sed -i -E "s/(pivpnDNS2=).+/\1/g" /etc/pivpn/wireguard/setupVars.conf
-
+          curl -L https://install.pivpn.io | bash /dev/stdin --unattended pivpn.conf --use-pihole
       Tags:
         - Key: Name
           Value: pivpn-pihole


### PR DESCRIPTION
Given the merge for https://github.com/pivpn/pivpn/pull/1825, use `--use-pihole` flag to solve https://github.com/JonnyMe/cloudformation-template-with-pihole-pivpn/issues/1